### PR TITLE
アンドゥ機能を実装（履歴5件）

### DIFF
--- a/src/VttEditor.tsx
+++ b/src/VttEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useRef, useEffect } from "react";
+import React, { useState, useMemo, useRef, useEffect, useCallback } from "react";
 import { shouldBlockPageLeave } from "./beforeUnload";
 
 // VTTの各セグメント（Cue）の型定義
@@ -67,14 +67,30 @@ const VttEditor: React.FC = () => {
     setCues(nextCues);
   };
 
-  const handleUndo = () => {
+  const handleUndo = useCallback(() => {
     setUndoStack((prev) => {
       if (prev.length === 0) return prev;
       const previousCues = prev[prev.length - 1];
       setCues(previousCues);
       return prev.slice(0, prev.length - 1);
     });
-  };
+  }, []);
+
+  // Ctrl+Z（MacではCmd+Z）でアンドゥ
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const isUndoKey = (event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "z";
+      if (!isUndoKey) return;
+      if (undoStack.length === 0) return;
+      event.preventDefault();
+      handleUndo();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [handleUndo, undoStack.length]);
 
   const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];

--- a/src/VttEditor.tsx
+++ b/src/VttEditor.tsx
@@ -10,7 +10,9 @@ interface VttCue {
 }
 
 const VttEditor: React.FC = () => {
+  const UNDO_BUFFER_SIZE = 5;
   const [cues, setCues] = useState<VttCue[]>([]);
+  const [undoStack, setUndoStack] = useState<VttCue[][]>([]);
   const [currentIndex, setCurrentIndex] = useState<number | null>(null);
   const [searchTerm, setSearchTerm] = useState("");
   const [isRegex, setIsRegex] = useState(false);
@@ -54,6 +56,26 @@ const VttEditor: React.FC = () => {
   }, [cues.length]);
 
   // --- ファイル処理 ---
+  const updateCuesWithUndo = (nextCues: VttCue[]) => {
+    setUndoStack((prev) => {
+      const nextStack = [...prev, cues];
+      if (nextStack.length > UNDO_BUFFER_SIZE) {
+        return nextStack.slice(nextStack.length - UNDO_BUFFER_SIZE);
+      }
+      return nextStack;
+    });
+    setCues(nextCues);
+  };
+
+  const handleUndo = () => {
+    setUndoStack((prev) => {
+      if (prev.length === 0) return prev;
+      const previousCues = prev[prev.length - 1];
+      setCues(previousCues);
+      return prev.slice(0, prev.length - 1);
+    });
+  };
+
   const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
@@ -83,6 +105,7 @@ const VttEditor: React.FC = () => {
         }
       }
     });
+    setUndoStack([]);
     setCues(parsedCues);
   };
 
@@ -107,7 +130,7 @@ const VttEditor: React.FC = () => {
     };
 
     updatedCues.splice(index + 1, 1); // 次の行を削除
-    setCues(updatedCues);
+    updateCuesWithUndo(updatedCues);
   };
 
   // --- 要件2: タイムスタンプジャンプ ---
@@ -327,6 +350,13 @@ const VttEditor: React.FC = () => {
           }}
         >
           <input type="file" onChange={handleFileUpload} accept=".vtt,.txt" />
+          <button
+            onClick={handleUndo}
+            disabled={undoStack.length === 0}
+            style={{ marginLeft: "8px" }}
+          >
+            アンドゥ
+          </button>
           <div style={{ marginTop: "10px" }}>
             <input
               placeholder="Search..."
@@ -415,7 +445,7 @@ const VttEditor: React.FC = () => {
                   onChange={(e) => {
                     const newCues = [...cues];
                     newCues[idx].text = e.target.value;
-                    setCues(newCues);
+                    updateCuesWithUndo(newCues);
                   }}
                 />
                 <button onClick={() => mergeNext(idx)}>Merge with Next</button>


### PR DESCRIPTION
### Motivation
- VTTエディタに編集や行マージを元に戻すアンドゥ機能を追加し、誤編集からの回復を容易にするため、履歴バッファを一旦5件に制限します。

### Description
- `UNDO_BUFFER_SIZE` を追加し、履歴上限を `5` に設定しました（`src/VttEditor.tsx`）。
- 編集履歴を保持するために `undoStack` state を導入し、`updateCuesWithUndo` を追加して操作前の `cues` スナップショットを積むようにしました。 
- `handleUndo` を追加して直近の履歴に戻せるようにし、ファイル読み込み時は履歴をクリアするように変更しました。 
- 行マージ処理とテキスト編集の `setCues` 呼び出しを `updateCuesWithUndo` に置き換え、UI に無効化状態付きの「アンドゥ」ボタンを追加しました。 

### Testing
- `npm run build` を実行し `tsc -b` と `vite build` が正常終了することを確認しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f81aa9fea88322986ff3e6e3561b4f)