### PR TITLE
Issue 4: 音声ミニプレーヤーを追加（F9 / ダブルクリックで再生・一時停止）

### DIFF
--- a/src/VttEditor.tsx
+++ b/src/VttEditor.tsx
@@ -25,7 +25,11 @@ const VttEditor: React.FC = () => {
     const saved = localStorage.getItem("vtt-file-extension");
     return saved || "txt";
   });
+  const [audioUrl, setAudioUrl] = useState<string>("");
+  const [audioFileName, setAudioFileName] = useState<string>("");
+  const [isPlaying, setIsPlaying] = useState(false);
   const scrollRef = useRef<{ [key: string]: HTMLDivElement | null }>({});
+  const audioRef = useRef<HTMLAudioElement | null>(null);
 
   // Thresholdが変更されたらローカルストレージに保存
   useEffect(() => {
@@ -101,6 +105,24 @@ const VttEditor: React.FC = () => {
     }
   };
 
+  const handleAudioUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const newAudioUrl = URL.createObjectURL(file);
+    setAudioUrl((prev) => {
+      if (prev) URL.revokeObjectURL(prev);
+      return newAudioUrl;
+    });
+    setAudioFileName(file.name);
+    setIsPlaying(false);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (audioUrl) URL.revokeObjectURL(audioUrl);
+    };
+  }, [audioUrl]);
+
   const parseVtt = (content: string) => {
     const lines = content.split("\n");
     const parsedCues: VttCue[] = [];
@@ -154,6 +176,46 @@ const VttEditor: React.FC = () => {
     setCurrentIndex(index);
     scrollRef.current[cues[index].id]?.scrollIntoView({ behavior: "smooth" });
   };
+
+  const timestampToSeconds = (timestamp: string) => {
+    const [hh, mm, ssMs] = timestamp.split(":");
+    if (!hh || !mm || !ssMs) return 0;
+    const [ss, ms = "0"] = ssMs.split(".");
+    return Number(hh) * 3600 + Number(mm) * 60 + Number(ss) + Number(`0.${ms}`);
+  };
+
+  const playPauseFromCue = useCallback((index: number) => {
+    if (!audioRef.current || !audioUrl) return;
+    const targetCue = cues[index];
+    if (!targetCue) return;
+    setCurrentIndex(index);
+    const player = audioRef.current;
+    if (player.paused) {
+      player.currentTime = timestampToSeconds(targetCue.startTime);
+      player.play().then(() => {
+        setIsPlaying(true);
+      }).catch(() => {
+        setIsPlaying(false);
+      });
+      return;
+    }
+    player.pause();
+    setIsPlaying(false);
+  }, [audioUrl, cues]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "F9") return;
+      if (currentIndex === null) return;
+      event.preventDefault();
+      playPauseFromCue(currentIndex);
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [currentIndex, playPauseFromCue]);
 
   // --- 要件3: 指定文字数を下回る行までジャンプ ---
   const jumpToShortLine = () => {
@@ -321,6 +383,7 @@ const VttEditor: React.FC = () => {
             <div
               key={cue.id}
               onClick={() => jumpToCue(idx)}
+              onDoubleClick={() => playPauseFromCue(idx)}
               style={{
                 cursor: "pointer",
                 padding: "8px 4px",
@@ -366,6 +429,12 @@ const VttEditor: React.FC = () => {
           }}
         >
           <input type="file" onChange={handleFileUpload} accept=".vtt,.txt" />
+          <input
+            type="file"
+            onChange={handleAudioUpload}
+            accept="audio/*"
+            style={{ marginLeft: "8px" }}
+          />
           <button
             onClick={handleUndo}
             disabled={undoStack.length === 0}
@@ -480,6 +549,29 @@ const VttEditor: React.FC = () => {
             background: "#f9f9f9",
           }}
         >
+          <label style={{ fontSize: "0.9em", fontWeight: "bold" }}>
+            ミニプレーヤー:
+            {audioUrl ? (
+              <span style={{ marginLeft: "5px", fontWeight: "normal" }}>
+                {audioFileName} ({isPlaying ? "再生中" : "停止中"})
+              </span>
+            ) : (
+              <span style={{ marginLeft: "5px", fontWeight: "normal", color: "#666" }}>
+                音声ファイル未読み込み
+              </span>
+            )}
+          </label>
+          {audioUrl && (
+            <audio
+              ref={audioRef}
+              src={audioUrl}
+              controls
+              style={{ maxWidth: "320px" }}
+              onPlay={() => setIsPlaying(true)}
+              onPause={() => setIsPlaying(false)}
+              onEnded={() => setIsPlaying(false)}
+            />
+          )}
           <label style={{ fontSize: "0.9em", fontWeight: "bold" }}>
             保存拡張子:
             <select

--- a/src/VttEditor.tsx
+++ b/src/VttEditor.tsx
@@ -33,6 +33,7 @@ const VttEditor: React.FC = () => {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const vttInputRef = useRef<HTMLInputElement | null>(null);
   const audioInputRef = useRef<HTMLInputElement | null>(null);
+  const playbackCueIndexRef = useRef<number | null>(null);
 
   // Thresholdが変更されたらローカルストレージに保存
   useEffect(() => {
@@ -214,18 +215,17 @@ const VttEditor: React.FC = () => {
     if (!audioRef.current) return;
     const activeCueIndex = findCueIndexByTime(audioRef.current.currentTime);
     if (activeCueIndex === -1) return;
-    setCurrentIndex((prev) => {
-      if (prev === activeCueIndex) return prev;
-      const targetElement = scrollRef.current[cues[activeCueIndex].id];
-      if (
-        isAutoScrollEnabled &&
-        targetElement &&
-        !isElementVisibleInViewport(targetElement)
-      ) {
-        targetElement.scrollIntoView({ behavior: "smooth", block: "center" });
-      }
-      return activeCueIndex;
-    });
+    if (playbackCueIndexRef.current === activeCueIndex) return;
+    playbackCueIndexRef.current = activeCueIndex;
+    const targetElement = scrollRef.current[cues[activeCueIndex].id];
+    if (
+      isAutoScrollEnabled &&
+      targetElement &&
+      !isElementVisibleInViewport(targetElement)
+    ) {
+      targetElement.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+    setCurrentIndex(activeCueIndex);
   }, [cues, findCueIndexByTime, isAutoScrollEnabled]);
 
   const playFromCue = useCallback((index: number) => {
@@ -233,6 +233,7 @@ const VttEditor: React.FC = () => {
     const targetCue = cues[index];
     if (!targetCue) return;
     setCurrentIndex(index);
+    playbackCueIndexRef.current = index;
     const player = audioRef.current;
     player.currentTime = timestampToSeconds(targetCue.startTime);
     player.play().catch(() => {

--- a/src/VttEditor.tsx
+++ b/src/VttEditor.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useMemo, useRef, useEffect, useCallback } from "react";
+import React, {
+  useState,
+  useMemo,
+  useRef,
+  useEffect,
+  useCallback,
+} from "react";
 import { shouldBlockPageLeave } from "./beforeUnload";
 
 // VTTの各セグメント（Cue）の型定義
@@ -27,7 +33,9 @@ const VttEditor: React.FC = () => {
   });
   const [audioUrl, setAudioUrl] = useState<string>("");
   const [audioFileName, setAudioFileName] = useState<string>("");
-  const [audioStatus, setAudioStatus] = useState<"未読み込み" | "再生中" | "停止中">("未読み込み");
+  const [audioStatus, setAudioStatus] = useState<
+    "未読み込み" | "再生中" | "停止中"
+  >("未読み込み");
   const [isAutoScrollEnabled, setIsAutoScrollEnabled] = useState(true);
   const scrollRef = useRef<{ [key: string]: HTMLDivElement | null }>({});
   const audioRef = useRef<HTMLAudioElement | null>(null);
@@ -87,7 +95,8 @@ const VttEditor: React.FC = () => {
   // Ctrl+Z（MacではCmd+Z）でアンドゥ
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      const isUndoKey = (event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "z";
+      const isUndoKey =
+        (event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "z";
       if (!isUndoKey) return;
       if (undoStack.length === 0) return;
       event.preventDefault();
@@ -198,13 +207,16 @@ const VttEditor: React.FC = () => {
     return Number(hh) * 3600 + Number(mm) * 60 + Number(ss) + Number(`0.${ms}`);
   };
 
-  const findCueIndexByTime = useCallback((time: number) => {
-    return cues.findIndex((cue) => {
-      const start = timestampToSeconds(cue.startTime);
-      const end = timestampToSeconds(cue.endTime);
-      return time >= start && time <= end;
-    });
-  }, [cues]);
+  const findCueIndexByTime = useCallback(
+    (time: number) => {
+      return cues.findIndex((cue) => {
+        const start = timestampToSeconds(cue.startTime);
+        const end = timestampToSeconds(cue.endTime);
+        return time >= start && time <= end;
+      });
+    },
+    [cues],
+  );
 
   const isElementVisibleInViewport = (element: HTMLElement) => {
     const rect = element.getBoundingClientRect();
@@ -228,19 +240,22 @@ const VttEditor: React.FC = () => {
     setCurrentIndex(activeCueIndex);
   }, [cues, findCueIndexByTime, isAutoScrollEnabled]);
 
-  const playFromCue = useCallback((index: number) => {
-    if (!audioRef.current || !audioUrl) return;
-    const targetCue = cues[index];
-    if (!targetCue) return;
-    setCurrentIndex(index);
-    playbackCueIndexRef.current = index;
-    const player = audioRef.current;
-    player.currentTime = timestampToSeconds(targetCue.startTime);
-    player.play().catch(() => {
-      // 自動再生制限などで再生できない場合は何もしない
-    });
-    setAudioStatus("再生中");
-  }, [audioUrl, cues]);
+  const playFromCue = useCallback(
+    (index: number) => {
+      if (!audioRef.current || !audioUrl) return;
+      const targetCue = cues[index];
+      if (!targetCue) return;
+      setCurrentIndex(index);
+      playbackCueIndexRef.current = index;
+      const player = audioRef.current;
+      player.currentTime = timestampToSeconds(targetCue.startTime);
+      player.play().catch(() => {
+        // 自動再生制限などで再生できない場合は何もしない
+      });
+      setAudioStatus("再生中");
+    },
+    [audioUrl, cues],
+  );
 
   const pauseAudio = useCallback(() => {
     if (!audioRef.current) return;
@@ -249,14 +264,17 @@ const VttEditor: React.FC = () => {
     setAudioStatus("停止中");
   }, []);
 
-  const playPauseFromCue = useCallback((index: number) => {
-    if (!audioRef.current) return;
-    if (audioRef.current.paused) {
-      playFromCue(index);
-      return;
-    }
-    pauseAudio();
-  }, [pauseAudio, playFromCue]);
+  const playPauseFromCue = useCallback(
+    (index: number) => {
+      if (!audioRef.current) return;
+      if (audioRef.current.paused) {
+        playFromCue(index);
+        return;
+      }
+      pauseAudio();
+    },
+    [pauseAudio, playFromCue],
+  );
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -434,19 +452,18 @@ const VttEditor: React.FC = () => {
 
           <h3>Cues</h3>
           {cues.map((cue, idx) => {
-            const { speaker, preview, plainText, previewLength } = getCuePreview(
-              cue.text,
-            );
+            const { speaker, preview, plainText, previewLength } =
+              getCuePreview(cue.text);
 
-          // 背景色の決定ロジック
-          let bgColor = "transparent";
-          if (currentIndex === idx) {
-            bgColor = "#e0f0ff"; // 選択中 (青)
-          } else if (plainText.length < charThreshold) {
-            bgColor = "#fff9c4"; // 文字数不足 (黄)
-          } else if (/[、，,]$/.test(plainText)) {
-            bgColor = "#ffe0b2"; // 句読点で終了 (オレンジ)
-          }
+            // 背景色の決定ロジック
+            let bgColor = "transparent";
+            if (currentIndex === idx) {
+              bgColor = "#e0f0ff"; // 選択中 (青)
+            } else if (plainText.length < charThreshold) {
+              bgColor = "#fff9c4"; // 文字数不足 (黄)
+            } else if (/[、，,]$/.test(plainText)) {
+              bgColor = "#ffe0b2"; // 句読点で終了 (オレンジ)
+            }
 
             return (
               <div
@@ -497,9 +514,16 @@ const VttEditor: React.FC = () => {
             padding: "10px",
           }}
         >
-          <div style={{ fontSize: "0.9em", fontWeight: "bold", marginBottom: "6px" }}>
-            ミニプレーヤー
-          </div>
+          <h3
+            style={{
+              fontSize: "0.9em",
+              fontWeight: "bold",
+              marginTop: 0,
+              marginBottom: "6px",
+            }}
+          >
+            Player(F9:再生 / F10:停止)
+          </h3>
           {audioUrl ? (
             <audio
               ref={audioRef}
@@ -513,9 +537,13 @@ const VttEditor: React.FC = () => {
               onEnded={() => setAudioStatus("停止中")}
             />
           ) : (
-            <div style={{ fontSize: "0.8em", color: "#666" }}>音声ファイル未読み込み</div>
+            <div style={{ fontSize: "0.8em", color: "#666" }}>
+              音声ファイル未読み込み
+            </div>
           )}
-          <label style={{ fontSize: "0.85em", display: "block", marginTop: "6px" }}>
+          <label
+            style={{ fontSize: "0.85em", display: "block", marginTop: "6px" }}
+          >
             <input
               type="checkbox"
               checked={isAutoScrollEnabled}

--- a/src/VttEditor.tsx
+++ b/src/VttEditor.tsx
@@ -30,6 +30,8 @@ const VttEditor: React.FC = () => {
   const [isPlaying, setIsPlaying] = useState(false);
   const scrollRef = useRef<{ [key: string]: HTMLDivElement | null }>({});
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const vttInputRef = useRef<HTMLInputElement | null>(null);
+  const audioInputRef = useRef<HTMLInputElement | null>(null);
 
   // Thresholdが変更されたらローカルストレージに保存
   useEffect(() => {
@@ -103,6 +105,16 @@ const VttEditor: React.FC = () => {
       reader.onload = (ev) => parseVtt(ev.target?.result as string);
       reader.readAsText(file);
     }
+  };
+
+  const fileSelectButtonStyle: React.CSSProperties = {
+    border: "1px solid #ccc",
+    background: "#fff",
+    color: "#333",
+    borderRadius: "6px",
+    padding: "6px 10px",
+    fontSize: "0.9em",
+    cursor: "pointer",
   };
 
   const handleAudioUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -428,13 +440,32 @@ const VttEditor: React.FC = () => {
             background: "#f9f9f9",
           }}
         >
-          <input type="file" onChange={handleFileUpload} accept=".vtt,.txt" />
           <input
+            ref={vttInputRef}
+            type="file"
+            onChange={handleFileUpload}
+            accept=".vtt,.txt"
+            style={{ display: "none" }}
+          />
+          <button
+            onClick={() => vttInputRef.current?.click()}
+            style={fileSelectButtonStyle}
+          >
+            VTTファイルを選択
+          </button>
+          <input
+            ref={audioInputRef}
             type="file"
             onChange={handleAudioUpload}
             accept="audio/*"
-            style={{ marginLeft: "8px" }}
+            style={{ display: "none" }}
           />
+          <button
+            onClick={() => audioInputRef.current?.click()}
+            style={{ ...fileSelectButtonStyle, marginLeft: "8px" }}
+          >
+            音声ファイルを選択
+          </button>
           <button
             onClick={handleUndo}
             disabled={undoStack.length === 0}

--- a/src/VttEditor.tsx
+++ b/src/VttEditor.tsx
@@ -27,7 +27,6 @@ const VttEditor: React.FC = () => {
   });
   const [audioUrl, setAudioUrl] = useState<string>("");
   const [audioFileName, setAudioFileName] = useState<string>("");
-  const [isPlaying, setIsPlaying] = useState(false);
   const [isAutoScrollEnabled, setIsAutoScrollEnabled] = useState(true);
   const scrollRef = useRef<{ [key: string]: HTMLDivElement | null }>({});
   const audioRef = useRef<HTMLAudioElement | null>(null);
@@ -127,7 +126,6 @@ const VttEditor: React.FC = () => {
       return newAudioUrl;
     });
     setAudioFileName(file.name);
-    setIsPlaying(false);
   };
 
   useEffect(() => {
@@ -235,10 +233,8 @@ const VttEditor: React.FC = () => {
     setCurrentIndex(index);
     const player = audioRef.current;
     player.currentTime = timestampToSeconds(targetCue.startTime);
-    player.play().then(() => {
-      setIsPlaying(true);
-    }).catch(() => {
-      setIsPlaying(false);
+    player.play().catch(() => {
+      // 自動再生制限などで再生できない場合は何もしない
     });
   }, [audioUrl, cues]);
 
@@ -246,7 +242,6 @@ const VttEditor: React.FC = () => {
     if (!audioRef.current) return;
     const player = audioRef.current;
     player.pause();
-    setIsPlaying(false);
   }, []);
 
   const playPauseFromCue = useCallback((index: number) => {
@@ -387,48 +382,50 @@ const VttEditor: React.FC = () => {
         style={{
           width: "300px",
           borderRight: "1px solid #ccc",
-          overflowY: "auto",
           padding: "10px",
+          display: "flex",
+          flexDirection: "column",
         }}
       >
-        <h3>Speakers</h3>
-        <div
-          style={{
-            marginBottom: "20px",
-            display: "flex",
-            flexWrap: "wrap",
-            gap: "5px",
-          }}
-        >
-          {uniqueSpeakers.length > 0 ? (
-            uniqueSpeakers.map((speaker) => (
-              <span
-                key={speaker}
-                style={{
-                  padding: "2px 8px",
-                  backgroundColor: "#e7f3ff",
-                  color: "#007bff",
-                  borderRadius: "12px",
-                  fontSize: "0.75em",
-                  fontWeight: "bold",
-                  border: "1px solid #cce5ff",
-                }}
-              >
-                {speaker}
+        <div style={{ overflowY: "auto", flex: 1 }}>
+          <h3>Speakers</h3>
+          <div
+            style={{
+              marginBottom: "20px",
+              display: "flex",
+              flexWrap: "wrap",
+              gap: "5px",
+            }}
+          >
+            {uniqueSpeakers.length > 0 ? (
+              uniqueSpeakers.map((speaker) => (
+                <span
+                  key={speaker}
+                  style={{
+                    padding: "2px 8px",
+                    backgroundColor: "#e7f3ff",
+                    color: "#007bff",
+                    borderRadius: "12px",
+                    fontSize: "0.75em",
+                    fontWeight: "bold",
+                    border: "1px solid #cce5ff",
+                  }}
+                >
+                  {speaker}
+                </span>
+              ))
+            ) : (
+              <span style={{ fontSize: "0.8em", color: "#999" }}>
+                No speakers found
               </span>
-            ))
-          ) : (
-            <span style={{ fontSize: "0.8em", color: "#999" }}>
-              No speakers found
-            </span>
-          )}
-        </div>
+            )}
+          </div>
 
-        <h3>Cues</h3>
-        {cues.map((cue, idx) => {
-          const { speaker, preview, plainText, previewLength } = getCuePreview(
-            cue.text,
-          );
+          <h3>Cues</h3>
+          {cues.map((cue, idx) => {
+            const { speaker, preview, plainText, previewLength } = getCuePreview(
+              cue.text,
+            );
 
           // 背景色の決定ロジック
           let bgColor = "transparent";
@@ -440,44 +437,70 @@ const VttEditor: React.FC = () => {
             bgColor = "#ffe0b2"; // 句読点で終了 (オレンジ)
           }
 
-          return (
-            <div
-              key={cue.id}
-              onClick={() => jumpToCue(idx)}
-              onDoubleClick={() => playPauseFromCue(idx)}
-              style={{
-                cursor: "pointer",
-                padding: "8px 4px",
-                fontSize: "0.85em",
-                borderBottom: "1px solid #eee",
-                backgroundColor: bgColor,
-              }}
-            >
-              <div style={{ fontWeight: "bold", marginBottom: "2px" }}>
-                {cue.startTime}
-              </div>
+            return (
               <div
+                key={cue.id}
+                onClick={() => jumpToCue(idx)}
+                onDoubleClick={() => playPauseFromCue(idx)}
                 style={{
-                  whiteSpace: "nowrap",
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
+                  cursor: "pointer",
+                  padding: "8px 4px",
+                  fontSize: "0.85em",
+                  borderBottom: "1px solid #eee",
+                  backgroundColor: bgColor,
                 }}
               >
-                {speaker && (
-                  <span style={{ color: "#007bff", fontWeight: "bold" }}>
-                    [{speaker}]
-                  </span>
-                )}
-                <span
-                  style={{ marginLeft: speaker ? "5px" : "0", color: "#555" }}
+                <div style={{ fontWeight: "bold", marginBottom: "2px" }}>
+                  {cue.startTime}
+                </div>
+                <div
+                  style={{
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                  }}
                 >
-                  {preview}
-                  {plainText.length > previewLength ? "..." : ""}
-                </span>
+                  {speaker && (
+                    <span style={{ color: "#007bff", fontWeight: "bold" }}>
+                      [{speaker}]
+                    </span>
+                  )}
+                  <span
+                    style={{ marginLeft: speaker ? "5px" : "0", color: "#555" }}
+                  >
+                    {preview}
+                    {plainText.length > previewLength ? "..." : ""}
+                  </span>
+                </div>
               </div>
-            </div>
-          );
-        })}
+            );
+          })}
+        </div>
+        <div style={{ marginTop: "10px", borderTop: "1px solid #ddd", paddingTop: "10px" }}>
+          <div style={{ fontSize: "0.9em", fontWeight: "bold", marginBottom: "6px" }}>
+            ミニプレーヤー
+          </div>
+          {audioUrl ? (
+            <audio
+              ref={audioRef}
+              src={audioUrl}
+              controls
+              title={audioFileName}
+              style={{ width: "100%" }}
+              onTimeUpdate={handleAudioTimeUpdate}
+            />
+          ) : (
+            <div style={{ fontSize: "0.8em", color: "#666" }}>音声ファイル未読み込み</div>
+          )}
+          <label style={{ fontSize: "0.85em", display: "block", marginTop: "6px" }}>
+            <input
+              type="checkbox"
+              checked={isAutoScrollEnabled}
+              onChange={(e) => setIsAutoScrollEnabled(e.target.checked)}
+            />{" "}
+            スクロール
+          </label>
+        </div>
       </div>
 
       {/* メインエディタ */}
@@ -629,38 +652,6 @@ const VttEditor: React.FC = () => {
             background: "#f9f9f9",
           }}
         >
-          <label style={{ fontSize: "0.9em", fontWeight: "bold" }}>
-            ミニプレーヤー:
-            {audioUrl ? (
-              <span style={{ marginLeft: "5px", fontWeight: "normal" }}>
-                {audioFileName} ({isPlaying ? "再生中" : "停止中"})
-              </span>
-            ) : (
-              <span style={{ marginLeft: "5px", fontWeight: "normal", color: "#666" }}>
-                音声ファイル未読み込み
-              </span>
-            )}
-          </label>
-          {audioUrl && (
-            <audio
-              ref={audioRef}
-              src={audioUrl}
-              controls
-              style={{ maxWidth: "320px" }}
-              onPlay={() => setIsPlaying(true)}
-              onPause={() => setIsPlaying(false)}
-              onEnded={() => setIsPlaying(false)}
-              onTimeUpdate={handleAudioTimeUpdate}
-            />
-          )}
-          <label style={{ fontSize: "0.9em" }}>
-            <input
-              type="checkbox"
-              checked={isAutoScrollEnabled}
-              onChange={(e) => setIsAutoScrollEnabled(e.target.checked)}
-            />{" "}
-            スクロール
-          </label>
           <label style={{ fontSize: "0.9em", fontWeight: "bold" }}>
             保存拡張子:
             <select

--- a/src/VttEditor.tsx
+++ b/src/VttEditor.tsx
@@ -228,38 +228,55 @@ const VttEditor: React.FC = () => {
     });
   }, [cues, findCueIndexByTime, isAutoScrollEnabled]);
 
-  const playPauseFromCue = useCallback((index: number) => {
+  const playFromCue = useCallback((index: number) => {
     if (!audioRef.current || !audioUrl) return;
     const targetCue = cues[index];
     if (!targetCue) return;
     setCurrentIndex(index);
     const player = audioRef.current;
-    if (player.paused) {
-      player.currentTime = timestampToSeconds(targetCue.startTime);
-      player.play().then(() => {
-        setIsPlaying(true);
-      }).catch(() => {
-        setIsPlaying(false);
-      });
-      return;
-    }
+    player.currentTime = timestampToSeconds(targetCue.startTime);
+    player.play().then(() => {
+      setIsPlaying(true);
+    }).catch(() => {
+      setIsPlaying(false);
+    });
+  }, [audioUrl, cues]);
+
+  const pauseAudio = useCallback(() => {
+    if (!audioRef.current) return;
+    const player = audioRef.current;
     player.pause();
     setIsPlaying(false);
-  }, [audioUrl, cues]);
+  }, []);
+
+  const playPauseFromCue = useCallback((index: number) => {
+    if (!audioRef.current) return;
+    if (audioRef.current.paused) {
+      playFromCue(index);
+      return;
+    }
+    pauseAudio();
+  }, [pauseAudio, playFromCue]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== "F9") return;
-      if (currentIndex === null) return;
-      event.preventDefault();
-      playPauseFromCue(currentIndex);
+      if (event.key === "F9") {
+        if (currentIndex === null) return;
+        event.preventDefault();
+        playFromCue(currentIndex);
+        return;
+      }
+      if (event.key === "F10") {
+        event.preventDefault();
+        pauseAudio();
+      }
     };
 
     window.addEventListener("keydown", handleKeyDown);
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [currentIndex, playPauseFromCue]);
+  }, [currentIndex, pauseAudio, playFromCue]);
 
   // --- 要件3: 指定文字数を下回る行までジャンプ ---
   const jumpToShortLine = () => {

--- a/src/VttEditor.tsx
+++ b/src/VttEditor.tsx
@@ -28,6 +28,7 @@ const VttEditor: React.FC = () => {
   const [audioUrl, setAudioUrl] = useState<string>("");
   const [audioFileName, setAudioFileName] = useState<string>("");
   const [isPlaying, setIsPlaying] = useState(false);
+  const [isAutoScrollEnabled, setIsAutoScrollEnabled] = useState(true);
   const scrollRef = useRef<{ [key: string]: HTMLDivElement | null }>({});
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const vttInputRef = useRef<HTMLInputElement | null>(null);
@@ -195,6 +196,37 @@ const VttEditor: React.FC = () => {
     const [ss, ms = "0"] = ssMs.split(".");
     return Number(hh) * 3600 + Number(mm) * 60 + Number(ss) + Number(`0.${ms}`);
   };
+
+  const findCueIndexByTime = useCallback((time: number) => {
+    return cues.findIndex((cue) => {
+      const start = timestampToSeconds(cue.startTime);
+      const end = timestampToSeconds(cue.endTime);
+      return time >= start && time <= end;
+    });
+  }, [cues]);
+
+  const isElementVisibleInViewport = (element: HTMLElement) => {
+    const rect = element.getBoundingClientRect();
+    return rect.top >= 0 && rect.bottom <= window.innerHeight;
+  };
+
+  const handleAudioTimeUpdate = useCallback(() => {
+    if (!audioRef.current) return;
+    const activeCueIndex = findCueIndexByTime(audioRef.current.currentTime);
+    if (activeCueIndex === -1) return;
+    setCurrentIndex((prev) => {
+      if (prev === activeCueIndex) return prev;
+      const targetElement = scrollRef.current[cues[activeCueIndex].id];
+      if (
+        isAutoScrollEnabled &&
+        targetElement &&
+        !isElementVisibleInViewport(targetElement)
+      ) {
+        targetElement.scrollIntoView({ behavior: "smooth", block: "center" });
+      }
+      return activeCueIndex;
+    });
+  }, [cues, findCueIndexByTime, isAutoScrollEnabled]);
 
   const playPauseFromCue = useCallback((index: number) => {
     if (!audioRef.current || !audioUrl) return;
@@ -601,8 +633,17 @@ const VttEditor: React.FC = () => {
               onPlay={() => setIsPlaying(true)}
               onPause={() => setIsPlaying(false)}
               onEnded={() => setIsPlaying(false)}
+              onTimeUpdate={handleAudioTimeUpdate}
             />
           )}
+          <label style={{ fontSize: "0.9em" }}>
+            <input
+              type="checkbox"
+              checked={isAutoScrollEnabled}
+              onChange={(e) => setIsAutoScrollEnabled(e.target.checked)}
+            />{" "}
+            スクロール
+          </label>
           <label style={{ fontSize: "0.9em", fontWeight: "bold" }}>
             保存拡張子:
             <select

--- a/src/VttEditor.tsx
+++ b/src/VttEditor.tsx
@@ -27,6 +27,7 @@ const VttEditor: React.FC = () => {
   });
   const [audioUrl, setAudioUrl] = useState<string>("");
   const [audioFileName, setAudioFileName] = useState<string>("");
+  const [audioStatus, setAudioStatus] = useState<"未読み込み" | "再生中" | "停止中">("未読み込み");
   const [isAutoScrollEnabled, setIsAutoScrollEnabled] = useState(true);
   const scrollRef = useRef<{ [key: string]: HTMLDivElement | null }>({});
   const audioRef = useRef<HTMLAudioElement | null>(null);
@@ -126,6 +127,7 @@ const VttEditor: React.FC = () => {
       return newAudioUrl;
     });
     setAudioFileName(file.name);
+    setAudioStatus("停止中");
   };
 
   useEffect(() => {
@@ -236,12 +238,14 @@ const VttEditor: React.FC = () => {
     player.play().catch(() => {
       // 自動再生制限などで再生できない場合は何もしない
     });
+    setAudioStatus("再生中");
   }, [audioUrl, cues]);
 
   const pauseAudio = useCallback(() => {
     if (!audioRef.current) return;
     const player = audioRef.current;
     player.pause();
+    setAudioStatus("停止中");
   }, []);
 
   const playPauseFromCue = useCallback((index: number) => {
@@ -375,6 +379,12 @@ const VttEditor: React.FC = () => {
     return { speaker, preview, plainText, previewLength };
   };
 
+  const miniPlayerBgColor = (() => {
+    if (audioStatus === "再生中") return "#e8f7e8";
+    if (audioStatus === "停止中") return "#fdeaea";
+    return "#f1f1f1";
+  })();
+
   return (
     <div style={{ display: "flex", height: "100vh", fontFamily: "sans-serif" }}>
       {/* 左サイドバー: タイムスタンプ一覧 */}
@@ -476,7 +486,16 @@ const VttEditor: React.FC = () => {
             );
           })}
         </div>
-        <div style={{ marginTop: "10px", borderTop: "1px solid #ddd", paddingTop: "10px" }}>
+        <div
+          style={{
+            marginTop: "10px",
+            borderTop: "1px solid #ddd",
+            paddingTop: "10px",
+            backgroundColor: miniPlayerBgColor,
+            borderRadius: "6px",
+            padding: "10px",
+          }}
+        >
           <div style={{ fontSize: "0.9em", fontWeight: "bold", marginBottom: "6px" }}>
             ミニプレーヤー
           </div>
@@ -488,6 +507,9 @@ const VttEditor: React.FC = () => {
               title={audioFileName}
               style={{ width: "100%" }}
               onTimeUpdate={handleAudioTimeUpdate}
+              onPlay={() => setAudioStatus("再生中")}
+              onPause={() => setAudioStatus("停止中")}
+              onEnded={() => setAudioStatus("停止中")}
             />
           ) : (
             <div style={{ fontSize: "0.8em", color: "#666" }}>音声ファイル未読み込み</div>


### PR DESCRIPTION
### Motivation
- VTT読み込み済みの状態で音声ファイルを追加読み込みできるようにし、行のタイムスタンプから手早く再生／一時停止できるミニプレーヤーを提供するため。

### Description
- `src/VttEditor.tsx` に音声関連の状態と参照を追加し、`audioUrl`, `audioFileName`, `isPlaying`, `audioRef` を導入しました。 
- 音声ファイル入力 (`accept="audio/*"`) と `handleAudioUpload` を追加し、`URL.createObjectURL` の生成と差し替え時/アンマウント時の `URL.revokeObjectURL` を実装しました。 
- タイムスタンプを秒に変換する `timestampToSeconds` と、指定行の開始時刻へシークして再生／一時停止を切り替える `playPauseFromCue` を追加しました。 
- 各キュー行に `onDoubleClick` を追加してダブルクリックで再生／一時停止できるようにし、グローバルの `keydown` ハンドラで `F9` 押下時に現在選択行を再生／一時停止する動作を追加しました。 
- フッターにミニプレーヤー表示（ファイル名、再生状態、`<audio controls>`）を追加しました。 

### Testing
- `npm run build`（内部で `tsc -b && vite build` が実行）でビルドが成功することを確認しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f99c94dce883228bd904f51037f318)